### PR TITLE
fix: error on :AskGeminiPrompt due unmodifiable buffer

### DIFF
--- a/lua/askGemini.lua
+++ b/lua/askGemini.lua
@@ -58,6 +58,9 @@ local function set_popup_lines(popup_buffer, text_content)
         return
     end
 
+    -- Set buffer to be modifiable in order to clear it
+    vim.api.nvim_buf_set_option(popup_buffer, 'modifiable', true)
+
     -- Clear existing content
     vim.api.nvim_buf_set_lines(popup_buffer, 0, -1, false, {})
 

--- a/lua/askGemini.lua
+++ b/lua/askGemini.lua
@@ -1,7 +1,7 @@
 -- Title: askGimini
 -- Description: A plugin to ask questions to Google's Gemini
--- Last change: 1-April-2025 -- Using current date as requested
--- Manteiner: Navarro-Torres, Agustin (https://github.com/agusnt)
+-- Last change: 06-July-2025
+-- Maintainer: Navarro-Torres, Agustin (https://github.com/agusnt)
 
 -- Use local variables for better scoping
 local Popup = require("nui.popup")


### PR DESCRIPTION
Fixes [#3](https://github.com/agusnt/askGemini.nvim/issues/3).

By setting the buffer to modifiable right before clearing it should be fine. The buffer is set back to unmodifiable at the end of the function.